### PR TITLE
Fix dependency inconsistency

### DIFF
--- a/versions/2.5.3/requirements.txt
+++ b/versions/2.5.3/requirements.txt
@@ -10,7 +10,7 @@ apache-airflow-providers-common-sql==1.7.1
 apache-airflow-providers-databricks==4.6.0
 apache-airflow-providers-datadog==3.4.0
 apache-airflow-providers-dbt-cloud==3.4.0
-apache-airflow-providers-elasticsearch==5.0.1
+apache-airflow-providers-elasticsearch==5.0.0
 apache-airflow-providers-ftp==3.5.1
 apache-airflow-providers-google==10.7.0
 apache-airflow-providers-http==4.5.1

--- a/versions/2.7.1/requirements.txt
+++ b/versions/2.7.1/requirements.txt
@@ -10,7 +10,7 @@ apache-airflow-providers-common-sql==1.7.1
 apache-airflow-providers-databricks==4.6.0
 apache-airflow-providers-datadog==3.4.0
 apache-airflow-providers-dbt-cloud==3.4.0
-apache-airflow-providers-elasticsearch==5.0.1
+apache-airflow-providers-elasticsearch==5.0.0
 apache-airflow-providers-ftp==3.5.1
 apache-airflow-providers-google==10.7.0
 apache-airflow-providers-http==4.5.1


### PR DESCRIPTION
Change package version to fix the following error
```
#7 136.7 ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
#7 136.7 elasticsearch-dsl 7.4.1 requires elasticsearch<8.0.0,>=7.0.0, but you have elasticsearch 8.10.1 which is incompatible.
#7 136.7 elasticsearch-dbapi 0.2.10 requires elasticsearch<7.14,>7, but you have elasticsearch 8.10.1 which is incompatible.
```