### PR TITLE
Add cloud.double.airflow.image-version label

### DIFF
--- a/.github/workflows/manual-build-and-publish.yaml
+++ b/.github/workflows/manual-build-and-publish.yaml
@@ -76,6 +76,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             AIRFLOW_TAG=${{ env.AIRFLOW_TAG }}
+            BUILD_LABEL=${{ github.event.inputs.version }}-${{ env.BUILD_VERSION }}
       - name: Commit changes
         run: |
           git config user.name "GitHub Actions"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 ARG AIRFLOW_TAG
 FROM apache/airflow:${AIRFLOW_TAG}
+ARG BUILD_LABEL
+USER airflow
 COPY versions/${AIRFLOW_VERSION}/requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt
+LABEL cloud.double.airflow.image-version=${BUILD_LABEL}


### PR DESCRIPTION
1. Label generation added
2. `user` is duplicated from Airlfow image directive because security checks demanded so

Examples of labeled image: https://github.com/doublecloud/airflow-image/pkgs/container/airflow/157189037?tag=2.7.1-3
`"cloud.double.airflow.image-version": "2.7.1-3"`